### PR TITLE
Adds option to specify template parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ashby
+.env

--- a/model.go
+++ b/model.go
@@ -19,6 +19,10 @@ type PlotConfig struct {
 	// referenced in a dataset definition
 	Sources map[string]DataSource
 
+	// Template parameters can be provided on the command line. They
+	// are passed directly to the templating engine.
+	TemplateParams map[string]any
+
 	DefaultColor string
 
 	// Colors is a mapping of friendly names to hex values of colors

--- a/plot.go
+++ b/plot.go
@@ -49,8 +49,8 @@ var plotCommand = &cli.Command{
 			Destination: &plotOpts.sources,
 		},
 		&cli.StringSliceFlag{
-			Name:        "template-params",
-			Aliases:     []string{"t"},
+			Name:        "params",
+			Aliases:     []string{"p"},
 			Required:    false,
 			Usage:       "Specify templating parameters, in the format key=value. May be repeated to specify multiple parameters.",
 			Destination: &plotOpts.params,

--- a/template.go
+++ b/template.go
@@ -44,6 +44,7 @@ func ExecuteTemplate(ctx context.Context, source string, cfg *PlotConfig) (strin
 		"EndOfPreviousHour": cfg.BasisTime.Truncate(time.Hour).Add(-time.Nanosecond),
 		"EndOfPreviousDay":  cfg.BasisTime.Truncate(24 * time.Hour).Add(-time.Nanosecond),
 		"EndOfPreviousWeek": cfg.BasisTime.Truncate(7 * 24 * time.Hour).Add(-time.Nanosecond),
+		"Params":            cfg.TemplateParams,
 	}
 
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
For the website metrics pages, I want to use a single plot definition for multiple websites.

In this PR I added the option to provide templating parameters on the command line. 

That's how a call looks like now:

```shell
ashby plot --preview -s tiros=$SRC_TIROS -p website=ipld.io ../website/config/plotdefs/website-ttfb-gauge.yaml
```

Such plot definitions wouldn't work with the batch sub-command. Not sure how to handle that.