### PR TITLE
Add json editor to plot preview

### DIFF
--- a/plot.go
+++ b/plot.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MetalBlueberry/go-plotly/offline"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/exp/slog"
 	"gopkg.in/yaml.v3"
@@ -208,7 +207,9 @@ func Plot(cc *cli.Context) error {
 	fmt.Fprintln(out, string(data))
 
 	if plotOpts.preview {
-		offline.Show(fig)
+		if err := preview(fig); err != nil {
+			return fmt.Errorf("preview plot: %w", err)
+		}
 	}
 	return nil
 }

--- a/preview.go
+++ b/preview.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+
+	grob "github.com/MetalBlueberry/go-plotly/graph_objects"
+	"github.com/pkg/browser"
+)
+
+func preview(fig *grob.Fig) error {
+	figBytes, err := json.Marshal(fig)
+	if err != nil {
+		return fmt.Errorf("marshal fig: %w", err)
+	}
+
+	tmpl, err := template.New("plotly").Parse(baseHtml)
+	if err != nil {
+		return fmt.Errorf("parse plotly html: %w", err)
+	}
+
+	buf := &bytes.Buffer{}
+	if err = tmpl.Execute(buf, string(figBytes)); err != nil {
+		return fmt.Errorf("html template: %w", err)
+	}
+
+	return browser.OpenReader(buf)
+}
+
+var baseHtml = `
+<html>
+   <head>
+      <script src="https://cdn.plot.ly/plotly-1.58.4.min.js"></script>
+      <style id="plotly.js-style-global"></style>
+      <style id="plotly.js-style-modebar-2e7662"></style>
+
+      <link href="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/9.10.0/jsoneditor.css" rel="stylesheet" type="text/css">
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/9.10.0/jsoneditor.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
+   </head>
+   <body>
+      <div id="plot" class="js-plotly-plot"></div>
+      <div>
+         <p>
+            <button onclick="updatePlot();">Update</button>
+            <button id="copyYamlBtn" onclick="copyYaml();">Copy layout yaml</button>
+         </p>
+         <div id="jsoneditor" style="width: 100%; height: 800px;"></div>
+      </div>
+      
+      <script>
+        data = JSON.parse('{{ . }}')
+         
+        Plotly.newPlot('plot', data);
+
+        const container = document.getElementById("jsoneditor");
+        const editor = new JSONEditor(container, { mode: 'code' }, data);
+
+        function updatePlot() {
+            Plotly.newPlot('plot', editor.get());
+        }
+
+        function copyYaml() {
+            // get json and delete data field
+            var json = editor.get();
+            delete json.data;
+
+            // copy to clipboard
+            navigator.clipboard.writeText(jsyaml.dump(json));
+
+            // provide visual feedback
+            const container = document.getElementById("copyYamlBtn");
+            container.innerText = "Copied!";
+            setTimeout(function() {
+                container.innerText = "Copy layout yaml";
+            }, 1000);
+        }
+      </script>
+   </body>
+</html>
+	`

--- a/template.go
+++ b/template.go
@@ -41,10 +41,11 @@ func ExecuteTemplate(ctx context.Context, source string, cfg *PlotConfig) (strin
 
 		// The following are useful when formatting dates that are immediately before the start of the period
 		// They are not really suitable for use as the end of a range in a query.
-		"EndOfPreviousHour": cfg.BasisTime.Truncate(time.Hour).Add(-time.Nanosecond),
-		"EndOfPreviousDay":  cfg.BasisTime.Truncate(24 * time.Hour).Add(-time.Nanosecond),
-		"EndOfPreviousWeek": cfg.BasisTime.Truncate(7 * 24 * time.Hour).Add(-time.Nanosecond),
-		"Params":            cfg.TemplateParams,
+		"EndOfPreviousHour":   cfg.BasisTime.Truncate(time.Hour).Add(-time.Nanosecond),
+		"EndOfPreviousDay":    cfg.BasisTime.Truncate(24 * time.Hour).Add(-time.Nanosecond),
+		"EndOfPreviousWeek":   cfg.BasisTime.Truncate(7 * 24 * time.Hour).Add(-time.Nanosecond),
+		"StartOfPreviousWeek": cfg.BasisTime.Truncate(7 * 24 * time.Hour).Add(-7 * 24 * time.Hour),
+		"Params":              cfg.TemplateParams,
 	}
 
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
Adds a JSON editor below the graph for quick iteration:

<img width="1001" alt="image" src="https://github.com/plprobelab/ashby/assets/11836793/afa1a186-e987-46cc-87fd-33a07bd5babd">

- Clicking on "Update", refreshes the plot.
- Clicking on "Copy layout yaml" copies the `layout.*` part of the JSON to the clipboard (formatted as yaml).