### PR TITLE
Make processing profile source generic

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -335,8 +335,9 @@ func (p *ProcessingProfile) processPlotDefs(ctx context.Context, cfg *PlotConfig
 				}
 
 				figDat := FigureData{
-					Fig:    fig,
-					Params: pd.Parameters,
+					Fig:       fig,
+					Params:    pd.Parameters,
+					DynLayout: pd.DynLayout,
 				}
 
 				var data []byte

--- a/batch.go
+++ b/batch.go
@@ -180,7 +180,7 @@ func Batch(cc *cli.Context) error {
 		}
 
 		for _, profile := range profiles {
-			profile.Dir = filepath.Join(batchOpts.confDir, profile.Dir)
+			profile.Source = filepath.Join(batchOpts.confDir, profile.Source)
 
 			if len(profile.Variants) == 0 {
 				profile.Variants = []map[string]any{{}}
@@ -199,10 +199,20 @@ func Batch(cc *cli.Context) error {
 }
 
 func (p *ProcessingProfile) processPlotDefs(ctx context.Context, cfg *PlotConfig) error {
-	infs := os.DirFS(p.Dir)
-	fnames, err := fs.Glob(infs, "*.yaml")
-	if err != nil {
-		return fmt.Errorf("failed to read input directory: %w", err)
+	var (
+		infs   fs.FS
+		fnames []string
+		err    error
+	)
+	if p.SourceIsDir() {
+		infs = os.DirFS(p.Source)
+		fnames, err = fs.Glob(infs, "*.yaml")
+		if err != nil {
+			return fmt.Errorf("failed to read input directory: %w", err)
+		}
+	} else {
+		infs = os.DirFS(filepath.Dir(p.Source))
+		fnames = []string{filepath.Base(p.Source)}
 	}
 
 	for _, variant := range p.Variants {
@@ -250,7 +260,7 @@ func (p *ProcessingProfile) processPlotDefs(ctx context.Context, cfg *PlotConfig
 				}
 				logger.Debug("plot filename", "filepath", plotFilename)
 
-				info, err := os.Lstat(filepath.Join(p.Dir, fname))
+				info, err := os.Lstat(filepath.Join(filepath.Dir(p.Source), fname))
 				if err != nil {
 					return err
 				}

--- a/generate.go
+++ b/generate.go
@@ -366,22 +366,27 @@ func scalarTraces(dataSets map[string]DataSet, scalarDefs []ScalarDef, cfg *Plot
 				case DeltaTypeRelative:
 					trace.Delta = &grob.IndicatorDelta{
 						Reference:   dv,
-						Relative:    grob.True,
+						Relative:    grob.False,
 						Valueformat: ".2%",
 					}
-					trace.Mode = "number+delta"
-					if c := cfg.MaybeLookupColor(s.IncreaseColor, ""); c != "" {
-						trace.Delta.Increasing = &grob.IndicatorDeltaIncreasing{
-							Color: c,
-						}
-					}
-					if c := cfg.MaybeLookupColor(s.DecreaseColor, ""); c != "" {
-						trace.Delta.Decreasing = &grob.IndicatorDeltaDecreasing{
-							Color: c,
-						}
+				case DeltaTypeAbsolute:
+					trace.Delta = &grob.IndicatorDelta{
+						Reference: dv,
+						Relative:  grob.False,
 					}
 				default:
 					return nil, fmt.Errorf("unsupported delta type: %s", s.DeltaType)
+				}
+				trace.Mode = "number+delta"
+				if c := cfg.MaybeLookupColor(s.IncreaseColor, ""); c != "" {
+					trace.Delta.Increasing = &grob.IndicatorDeltaIncreasing{
+						Color: c,
+					}
+				}
+				if c := cfg.MaybeLookupColor(s.DecreaseColor, ""); c != "" {
+					trace.Delta.Decreasing = &grob.IndicatorDeltaDecreasing{
+						Color: c,
+					}
 				}
 			}
 
@@ -519,9 +524,61 @@ func tableTraces(dataSets map[string]DataSet, tablesDefs []TableDef, cfg *PlotCo
 					Colorscale:   "Viridis",
 					Colorbar:     lt.TableDef.Colorbar,
 					Reversescale: grob.Bool(&reverseScale),
+					Yaxis:        lt.TableDef.Yaxis,
 				}
 				traces = append(traces, trace)
 				annotations = append(annotations, lt.Annotations()...)
+			case TableTypeCategoryBar:
+				xLabels := [][]any{}
+				xLabels = append(xLabels, []any{}, []any{})
+				yValues := []any{}
+				for _, xLabel := range lt.LabelsX {
+					for _, yLabel := range lt.LabelsY {
+						xLabels[0] = append(xLabels[0], xLabel)
+						xLabels[1] = append(xLabels[1], yLabel)
+						yValues = append(yValues, lt.Values[xLabel][yLabel])
+					}
+				}
+				trace := &grob.Bar{
+					Type:  grob.TraceTypeBar,
+					Name:  lt.Name,
+					X:     xLabels,
+					Y:     yValues,
+					Yaxis: lt.TableDef.Yaxis,
+				}
+
+				if c := cfg.MaybeLookupColor(lt.TableDef.Color, lt.Name); c != "" {
+					trace.Marker = &grob.BarMarker{
+						Color: c,
+					}
+				}
+				traces = append(traces, trace)
+			case TableTypeMarkers:
+				xLabels := [][]any{}
+				xLabels = append(xLabels, []any{}, []any{})
+				yValues := []any{}
+				for _, xLabel := range lt.LabelsX {
+					for _, yLabel := range lt.LabelsY {
+						xLabels[0] = append(xLabels[0], xLabel)
+						xLabels[1] = append(xLabels[1], yLabel)
+						yValues = append(yValues, lt.Values[xLabel][yLabel])
+					}
+				}
+				trace := &grob.Scatter{
+					Type:  grob.TraceTypeScatter,
+					Name:  lt.Name,
+					X:     xLabels,
+					Y:     yValues,
+					Mode:  grob.ScatterModeMarkers,
+					Yaxis: lt.TableDef.Yaxis,
+				}
+				if c := cfg.MaybeLookupColor(lt.TableDef.Color, lt.Name); c != "" {
+					trace.Marker = &grob.ScatterMarker{
+						Color: c,
+					}
+				}
+				traces = append(traces, trace)
+
 			default:
 				return nil, nil, fmt.Errorf("unsupported table type: %s", lt.TableDef.Type)
 			}

--- a/model.go
+++ b/model.go
@@ -89,6 +89,7 @@ type PlotDef struct {
 	Layout     grob.Layout    `yaml:"layout"`
 	Config     grob.Config    `yaml:"config"`
 	Parameters map[string]any `yaml:"params"`
+	DynLayout  map[string]any `yaml:"dynamicLayout"`
 }
 
 type DataSetDef struct {
@@ -231,7 +232,8 @@ func (t ComputeType) String() string { return string(t) }
 
 type FigureData struct {
 	*grob.Fig
-	Params map[string]any `json:"params"`
+	Params    map[string]any `json:"params"`
+	DynLayout map[string]any `json:"dynamicLayout"`
 }
 
 type TableDef struct {

--- a/model.go
+++ b/model.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	grob "github.com/MetalBlueberry/go-plotly/graph_objects"
@@ -67,9 +68,14 @@ func (f PlotFrequency) Truncate(t time.Time) time.Time {
 }
 
 type ProcessingProfile struct {
-	Dir      string           `yaml:"directory"`
+	Source   string           `yaml:"source"`
 	OutTpl   string           `yaml:"output"`
 	Variants []map[string]any `yaml:"variants"`
+}
+
+func (p *ProcessingProfile) SourceIsDir() bool {
+	info, err := os.Stat(p.Source)
+	return err == nil && info.IsDir()
 }
 
 type PlotDef struct {

--- a/model.go
+++ b/model.go
@@ -178,6 +178,7 @@ type DeltaType string
 const (
 	DeltaTypeNone     DeltaType = ""
 	DeltaTypeRelative DeltaType = "relative" // the delta is an absolute value and should be displayed with a relative % change to the scalar
+	DeltaTypeAbsolute DeltaType = "absolute" // the delta is an absolute value and should be displayed with a relative % change to the scalar
 )
 
 func (t DeltaType) String() string { return string(t) }
@@ -243,14 +244,18 @@ type TableDef struct {
 	LabelsX  string                `yaml:"xLabels"`
 	LabelsY  string                `yaml:"yLabels"`
 	Values   string                `yaml:"values"`
+	Color    string                `yaml:"color"`
 	Colorbar *grob.HeatmapColorbar `yaml:"colorbar"`
+	Yaxis    string                `yaml:"yaxis"`
 	order    int                   // used for retaining ordering of series
 }
 
 type TableType string
 
 const (
-	TableTypeHeatmap TableType = "heatmap"
+	TableTypeHeatmap     TableType = "heatmap"
+	TableTypeCategoryBar TableType = "category+bar"
+	TableTypeMarkers     TableType = "markers"
 )
 
 func (t TableType) String() string { return string(t) }

--- a/plot.go
+++ b/plot.go
@@ -280,7 +280,7 @@ func parsePlotDef(fname string, content []byte) (*PlotDef, error) {
 		}
 
 		switch s.DeltaType {
-		case DeltaTypeNone, DeltaTypeRelative:
+		case DeltaTypeNone, DeltaTypeRelative, DeltaTypeAbsolute:
 		default:
 			return nil, fmt.Errorf("unknown scalar delta type: %q", s.DeltaType)
 		}
@@ -293,7 +293,7 @@ func parsePlotDef(fname string, content []byte) (*PlotDef, error) {
 
 	for _, t := range pd.Tables {
 		switch t.Type {
-		case TableTypeHeatmap:
+		case TableTypeHeatmap, TableTypeCategoryBar, TableTypeMarkers:
 		default:
 			return nil, fmt.Errorf("unknown table type: %q", t.Type)
 		}

--- a/plot.go
+++ b/plot.go
@@ -187,8 +187,9 @@ func Plot(cc *cli.Context) error {
 	}
 
 	figDat := FigureData{
-		Fig:    fig,
-		Params: pd.Parameters,
+		Fig:       fig,
+		Params:    pd.Parameters,
+		DynLayout: pd.DynLayout,
 	}
 
 	var data []byte


### PR DESCRIPTION
I found it easier (sometimes) to define the variants of a single plot definition and not for a whole directory of plot definitions. On the other hand sometimes it's nicer to just batch-generate a whole directory.

I changed the `Dir` field to be a source. Depending on if it's a directory or file it does the generation accordingly.