### PR TITLE
add bright threshold coloring to heatmap annotations

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -93,7 +93,12 @@ func generateFig(ctx context.Context, pd *PlotDef, cfg *PlotConfig) (*grob.Fig, 
 		return nil, fmt.Errorf("table traces: %w", err)
 	}
 	fig.Data = append(fig.Data, traces...)
-	fig.Layout.Annotations = annotations
+
+	if fig.Layout.Annotations == nil {
+		fig.Layout.Annotations = annotations
+	} else if existingAnnotations, ok := fig.Layout.Annotations.([]interface{}); ok {
+		fig.Layout.Annotations = append(existingAnnotations, annotations)
+	}
 
 	return fig, nil
 }

--- a/model.go
+++ b/model.go
@@ -113,18 +113,20 @@ type SeriesDef struct {
 	GroupValue    string     `yaml:"groupvalue"` // optional value of a field the series should use for grouping into related series
 	Percent       bool       `yaml:"percent"`
 	order         int        // used for retaining ordering of series
-	HoverTemplate string     `json:"hovertemplate,omitempty"`
-	Visible       bool       `json:"visible"`
+	HoverTemplate string     `yaml:"hovertemplate,omitempty"`
+	Visible       *bool      `yaml:"visible"`
+	Yaxis         string     `yaml:"yaxis"`
 }
 
 type SeriesType string
 
 const (
-	SeriesTypeBar  SeriesType = "bar"  // vertical bars
-	SeriesTypeHBar SeriesType = "hbar" // horizontal bars
-	SeriesTypeLine SeriesType = "line" // lines
-	SeriesTypeBox  SeriesType = "box"  // vertical box plot
-	SeriesTypeHBox SeriesType = "hbox" // horizontal box plot
+	SeriesTypeBar     SeriesType = "bar"     // vertical bars
+	SeriesTypeHBar    SeriesType = "hbar"    // horizontal bars
+	SeriesTypeLine    SeriesType = "line"    // lines
+	SeriesTypeScatter SeriesType = "scatter" // scatter
+	SeriesTypeBox     SeriesType = "box"     // vertical box plot
+	SeriesTypeHBox    SeriesType = "hbox"    // horizontal box plot
 )
 
 func (t SeriesType) String() string { return string(t) }
@@ -154,19 +156,21 @@ const (
 func (t MarkerType) String() string { return string(t) }
 
 type ScalarDef struct {
-	Type          ScalarType           `yaml:"type"`
-	Name          string               `yaml:"name"` // name of the scalar
-	Color         string               `yaml:"color"`
-	DataSet       string               `yaml:"dataset"`
-	Value         string               `yaml:"value"`         // the name of the field in the dataset that should be used for the scalar value
-	ValueSuffix   string               `yaml:"valueSuffix"`   // a string to append after the value
-	ValuePrefix   string               `yaml:"valuePrefix"`   // a string to prepend to the value
-	DeltaDataSet  string               `yaml:"deltaDataset"`  // the name of a dataset to use for a delta value
-	DeltaValue    string               `yaml:"deltaValue"`    // the name of the field in the delta dataset that should be used for the scalar value
-	DeltaType     DeltaType            `yaml:"deltaType"`     // the type of delta contained in the value field
-	IncreaseColor string               `yaml:"increaseColor"` // the color to use for delta that show an increase
-	DecreaseColor string               `yaml:"decreaseColor"` // the color to use for delta that show an increase
-	Gauge         *grob.IndicatorGauge `yaml:"gauge"`         // gauge configuration
+	Type          ScalarType            `yaml:"type"`
+	Name          string                `yaml:"name"` // name of the scalar
+	Color         string                `yaml:"color"`
+	DataSet       string                `yaml:"dataset"`
+	Value         string                `yaml:"value"`         // the name of the field in the dataset that should be used for the scalar value
+	ValueSuffix   string                `yaml:"valueSuffix"`   // a string to append after the value
+	ValuePrefix   string                `yaml:"valuePrefix"`   // a string to prepend to the value
+	DeltaDataSet  string                `yaml:"deltaDataset"`  // the name of a dataset to use for a delta value
+	DeltaValue    string                `yaml:"deltaValue"`    // the name of the field in the delta dataset that should be used for the scalar value
+	DeltaType     DeltaType             `yaml:"deltaType"`     // the type of delta contained in the value field
+	IncreaseColor string                `yaml:"increaseColor"` // the color to use for delta that show an increase
+	DecreaseColor string                `yaml:"decreaseColor"` // the color to use for delta that show an decrease
+	Visible       *bool                 `yaml:"visible"`       // if this trace should be shown
+	Gauge         *grob.IndicatorGauge  `yaml:"gauge"`         // gauge configuration
+	Domain        *grob.IndicatorDomain `yaml:"domain"`
 }
 
 type ScalarType string

--- a/model.go
+++ b/model.go
@@ -89,7 +89,7 @@ type PlotDef struct {
 	Scalars    []ScalarDef    `yaml:"scalars"`
 	Tables     []TableDef     `yaml:"tables"`
 	Layout     grob.Layout    `yaml:"layout"`
-	Config     grob.Config    `yaml:"config"`
+	Config     map[string]any `yaml:"config"`
 	Parameters map[string]any `yaml:"params"`
 	DynLayout  map[string]any `yaml:"dynamicLayout"`
 }
@@ -114,6 +114,7 @@ type SeriesDef struct {
 	Percent       bool       `yaml:"percent"`
 	order         int        // used for retaining ordering of series
 	HoverTemplate string     `json:"hovertemplate,omitempty"`
+	Visible       bool       `json:"visible"`
 }
 
 type SeriesType string
@@ -153,24 +154,26 @@ const (
 func (t MarkerType) String() string { return string(t) }
 
 type ScalarDef struct {
-	Type          ScalarType `yaml:"type"`
-	Name          string     `yaml:"name"` // name of the scalar
-	Color         string     `yaml:"color"`
-	DataSet       string     `yaml:"dataset"`
-	Value         string     `yaml:"value"`         // the name of the field in the dataset that should be used for the scalar value
-	ValueSuffix   string     `yaml:"valueSuffix"`   // a string to append after the value
-	ValuePrefix   string     `yaml:"valuePrefix"`   // a string to prepend to the value
-	DeltaDataSet  string     `yaml:"deltaDataset"`  // the name of a dataset to use for a delta value
-	DeltaValue    string     `yaml:"deltaValue"`    // the name of the field in the delta dataset that should be used for the scalar value
-	DeltaType     DeltaType  `yaml:"deltaType"`     // the type of delta contained in the value field
-	IncreaseColor string     `yaml:"increaseColor"` // the color to use for delta that show an increase
-	DecreaseColor string     `yaml:"decreaseColor"` // the color to use for delta that show an increase
+	Type          ScalarType           `yaml:"type"`
+	Name          string               `yaml:"name"` // name of the scalar
+	Color         string               `yaml:"color"`
+	DataSet       string               `yaml:"dataset"`
+	Value         string               `yaml:"value"`         // the name of the field in the dataset that should be used for the scalar value
+	ValueSuffix   string               `yaml:"valueSuffix"`   // a string to append after the value
+	ValuePrefix   string               `yaml:"valuePrefix"`   // a string to prepend to the value
+	DeltaDataSet  string               `yaml:"deltaDataset"`  // the name of a dataset to use for a delta value
+	DeltaValue    string               `yaml:"deltaValue"`    // the name of the field in the delta dataset that should be used for the scalar value
+	DeltaType     DeltaType            `yaml:"deltaType"`     // the type of delta contained in the value field
+	IncreaseColor string               `yaml:"increaseColor"` // the color to use for delta that show an increase
+	DecreaseColor string               `yaml:"decreaseColor"` // the color to use for delta that show an increase
+	Gauge         *grob.IndicatorGauge `yaml:"gauge"`         // gauge configuration
 }
 
 type ScalarType string
 
 const (
 	ScalarTypeNumber ScalarType = "number" // display the scalar value as a number
+	ScalarTypeGauge  ScalarType = "gauge"  // display the scalar value as a gauge
 )
 
 func (t ScalarType) String() string { return string(t) }
@@ -237,6 +240,7 @@ type FigureData struct {
 	*grob.Fig
 	Params    map[string]any `json:"params"`
 	DynLayout map[string]any `json:"dynamicLayout"`
+	Config    map[string]any `json:"config"`
 }
 
 type TableDef struct {

--- a/plot.go
+++ b/plot.go
@@ -190,6 +190,7 @@ func Plot(cc *cli.Context) error {
 		Fig:       fig,
 		Params:    pd.Parameters,
 		DynLayout: pd.DynLayout,
+		Config:    pd.Config,
 	}
 
 	var data []byte
@@ -215,7 +216,7 @@ func Plot(cc *cli.Context) error {
 	fmt.Fprintln(out, string(data))
 
 	if plotOpts.preview {
-		if err := preview(fig); err != nil {
+		if err := preview(figDat); err != nil {
 			return fmt.Errorf("preview plot: %w", err)
 		}
 	}
@@ -274,7 +275,7 @@ func parsePlotDef(fname string, content []byte) (*PlotDef, error) {
 
 	for _, s := range pd.Scalars {
 		switch s.Type {
-		case ScalarTypeNumber:
+		case ScalarTypeNumber, ScalarTypeGauge:
 		default:
 			return nil, fmt.Errorf("unknown scalar type: %q", s.Type)
 		}

--- a/plot.go
+++ b/plot.go
@@ -261,7 +261,7 @@ func parsePlotDef(fname string, content []byte) (*PlotDef, error) {
 
 	for _, s := range pd.Series {
 		switch s.Type {
-		case SeriesTypeBar, SeriesTypeHBar, SeriesTypeLine, SeriesTypeBox, SeriesTypeHBox:
+		case SeriesTypeBar, SeriesTypeHBar, SeriesTypeLine, SeriesTypeScatter, SeriesTypeBox, SeriesTypeHBox:
 		default:
 			return nil, fmt.Errorf("unknown series type: %q", s.Type)
 		}

--- a/preview.go
+++ b/preview.go
@@ -6,11 +6,10 @@ import (
 	"fmt"
 	"html/template"
 
-	grob "github.com/MetalBlueberry/go-plotly/graph_objects"
 	"github.com/pkg/browser"
 )
 
-func preview(fig *grob.Fig) error {
+func preview(fig FigureData) error {
 	figBytes, err := json.Marshal(fig)
 	if err != nil {
 		return fmt.Errorf("marshal fig: %w", err)
@@ -51,7 +50,7 @@ var baseHtml = `
       </div>
       
       <script>
-        data = JSON.parse('{{ . }}')
+        const data = JSON.parse('{{ . }}')
          
         Plotly.newPlot('plot', data);
 


### PR DESCRIPTION
Changelog

- heatmap annotations beyond a certain threshold will be white now
- annotations from the layout definition will extend the existing set instead of overwriting it