### PR TITLE
Fix failure to release postgres connections to pool

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -174,6 +174,11 @@ func Batch(cc *cli.Context) error {
 	}
 	cfg.BasisTime = cfg.BasisTime.UTC()
 	slog.Info("plots will be generated for time " + cfg.BasisTime.Format(time.RFC3339))
+	slog.Info("plot output directory: " + batchOpts.outDir)
+	slog.Info(fmt.Sprintf("using concurrency %d", batchOpts.concurrency))
+	if batchOpts.version {
+		slog.Info("plot output will be versioned")
+	}
 
 	for _, sopt := range batchOpts.sources.Value() {
 		name, url, ok := strings.Cut(sopt, "=")
@@ -193,6 +198,7 @@ func Batch(cc *cli.Context) error {
 	}
 
 	if batchOpts.confDir != "" {
+		slog.Info("reading config from: " + batchOpts.confDir)
 		conffs := os.DirFS(batchOpts.confDir)
 		colorConfContent, err := fs.ReadFile(conffs, "colors.yaml")
 		if err != nil {

--- a/batch.go
+++ b/batch.go
@@ -31,12 +31,14 @@ var batchCommand = &cli.Command{
 			Required:    false,
 			Usage:       "Emit compact json instead of pretty-printed.",
 			Destination: &batchOpts.compact,
+			EnvVars:     []string{envPrefix + "COMPACT"},
 		},
 		&cli.BoolFlag{
 			Name:        "validate",
 			Required:    false,
 			Usage:       "Validate the input files without running queries.",
 			Destination: &batchOpts.validate,
+			EnvVars:     []string{envPrefix + "VALIDATE"},
 		},
 		&cli.StringSliceFlag{
 			Name:        "source",
@@ -50,6 +52,7 @@ var batchCommand = &cli.Command{
 			Required:    true,
 			Usage:       "Path of directory where plots should be written.",
 			Destination: &batchOpts.outDir,
+			EnvVars:     []string{envPrefix + "OUT"},
 		},
 		&cli.StringFlag{
 			Name:        "basis",
@@ -57,18 +60,21 @@ var batchCommand = &cli.Command{
 			Value:       "now",
 			Usage:       "Basis time that should be passed to queries. Specify 'now', a valid date in the past in RFC3339 or Unix timestamp format or an offset from the current date in hours (e.g. -2h), days (e.g. -4d) or weeks (e.g. -1w).",
 			Destination: &batchOpts.basis,
+			EnvVars:     []string{envPrefix + "BASIS"},
 		},
 		&cli.BoolFlag{
 			Name:        "version",
 			Required:    true,
 			Usage:       "Automatically version the plots by writing to a dated hierarchy.",
 			Destination: &batchOpts.version,
+			EnvVars:     []string{envPrefix + "VERSION"},
 		},
 		&cli.BoolFlag{
 			Name:        "force",
 			Required:    false,
 			Usage:       "Force generation of plots even if the plot output already exists.",
 			Destination: &batchOpts.force,
+			EnvVars:     []string{envPrefix + "FORCE"},
 		},
 		&cli.IntFlag{
 			Name:        "concurrency",
@@ -76,18 +82,21 @@ var batchCommand = &cli.Command{
 			Usage:       "Number of concurrent goroutines to use for generating plots.",
 			Destination: &batchOpts.concurrency,
 			Value:       6,
+			EnvVars:     []string{envPrefix + "CONCURRENCY"},
 		},
 		&cli.StringFlag{
 			Name:        "conf",
 			Required:    false,
 			Usage:       "Path of directory containing configuration.",
 			Destination: &batchOpts.confDir,
+			EnvVars:     []string{envPrefix + "CONF"},
 		},
 		&cli.StringFlag{
 			Name:        "match",
 			Required:    false,
 			Usage:       "Only generate plotdefs that match this glob (use standard go glob syntax).",
 			Destination: &batchOpts.matchGlob,
+			EnvVars:     []string{envPrefix + "MATCH"},
 		},
 	}, loggingFlags...),
 }

--- a/logging.go
+++ b/logging.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/iand/pontium/hlog"
-	"github.com/urfave/cli/v2"
+	"os"
+
 	"golang.org/x/exp/slog"
 )
 
@@ -10,6 +10,7 @@ var loggingFlags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:        "verbose",
 		Aliases:     []string{"v"},
+		EnvVars:     []string{envPrefix + "VERBOSE"},
 		Usage:       "Set logging level more verbose to include info level logs",
 		Value:       true,
 		Destination: &loggingOpts.Verbose,
@@ -17,15 +18,24 @@ var loggingFlags = []cli.Flag{
 
 	&cli.BoolFlag{
 		Name:        "veryverbose",
-		Aliases:     []string{"vv"},
-		Usage:       "Set logging level more verbose to include debug level logs",
+		EnvVars:     []string{envPrefix + "VERYVERBOSE"},
+	Aliases: []string{"vv"},
+	Usage:   "Set logging level more verbose to include debug level logs",
 		Destination: &loggingOpts.VeryVerbose,
+	},
+	&cli.BoolFlag{
+		Name:        "hlog",
+		EnvVars:     []string{envPrefix + "HLOG"},
+		Usage:       "Use human friendly log output",
+		Value:       true,
+		Destination: &loggingOpts.Hlog,
 	},
 }
 
-var loggingOpts struct {
-	Verbose     bool
-	VeryVerbose bool
+
+
+v	VeryVerbose bool
+	Hlog        bool
 }
 
 func setupLogging() {
@@ -38,7 +48,13 @@ func setupLogging() {
 		logLevel.Set(slog.LevelDebug)
 	}
 
-	h := new(hlog.Handler)
-	h = h.WithLevel(logLevel.Level())
+	var h slog.Handler
+	if loggingOpts.Hlog {
+		h = new(hlog.Handler).WithLevel(logLevel.Level())
+	} else {
+		h = (slog.HandlerOptions{
+			Level: logLevel,
+		}).NewJSONHandler(os.Stdout)
+	}
 	slog.SetDefault(slog.New(h))
 }

--- a/logging.go
+++ b/logging.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 
+	"github.com/iand/pontium/hlog"
+	"github.com/urfave/cli/v2"
 	"golang.org/x/exp/slog"
 )
 
@@ -19,8 +21,8 @@ var loggingFlags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:        "veryverbose",
 		EnvVars:     []string{envPrefix + "VERYVERBOSE"},
-	Aliases: []string{"vv"},
-	Usage:   "Set logging level more verbose to include debug level logs",
+		Aliases:     []string{"vv"},
+		Usage:       "Set logging level more verbose to include debug level logs",
 		Destination: &loggingOpts.VeryVerbose,
 	},
 	&cli.BoolFlag{
@@ -34,7 +36,9 @@ var loggingFlags = []cli.Flag{
 
 
 
-v	VeryVerbose bool
+var loggingOpts struct {
+	Verbose     bool
+	VeryVerbose bool
 	Hlog        bool
 }
 


### PR DESCRIPTION
Fixes a hang condition where single-value plots were not reading the full postgres rowset and thereby not releasing the connection back to the pool. Instead we now read the entire rowset into a static structure and guarantee the release of the connection.

Also adds control of some options via environment variables.